### PR TITLE
Fix GitHub link in GitHub pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
                 </p>
 
                 <div class="links">
-                    <a href="https://github.com/angelCarias/pycordia/docs/" target="_blank">
+                    <a href="https://github.com/angelCarias/pycordia/" target="_blank">
                         <i class="fab fa-github fa-fw"></i> Look at our source code
                     </a>
                     <a href="/pycordia/docs/">


### PR DESCRIPTION
Fix the link to the GitHub page on https://angelcarias.github.io/pycordia/